### PR TITLE
Add Devanagari as a word-input option

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -51,6 +51,7 @@ global $inithash;
  output_option("HK","Harvard-Kyoto",$init);
  output_option("SLP2SLP","SLP1",$init);
  output_option("ITRANS","ITRANS",$init);
+ output_option("DEVA","Devanagari",$init);
 ?>
     </select>
    </td>

--- a/web/main.js
+++ b/web/main.js
@@ -28,6 +28,62 @@ function loadFcn() {
   }
 
 }
+// Devanagari -> SLP1 transliteration, so users can type in Devanagari
+// directly; the dal/getWord backend only understands the schemes it
+// already supports (Harvard-Kyoto, SLP1, ITRANS), so this runs client-side
+// before the request is sent and the "input" scheme is switched to SLP1.
+var DEVA_TO_SLP1_VOWELS = {
+ "अ":"a","आ":"A","इ":"i","ई":"I","उ":"u","ऊ":"U",
+ "ऋ":"f","ॠ":"F","ऌ":"x","ॡ":"X","ए":"e","ऐ":"E","ओ":"o","औ":"O"
+};
+var DEVA_TO_SLP1_MATRAS = {
+ "ा":"A","ि":"i","ी":"I","ु":"u","ू":"U",
+ "ृ":"f","ॄ":"F","ॢ":"x","ॣ":"X","े":"e","ै":"E","ो":"o","ौ":"O"
+};
+var DEVA_TO_SLP1_CONSONANTS = {
+ "क":"k","ख":"K","ग":"g","घ":"G","ङ":"N",
+ "च":"c","छ":"C","ज":"j","झ":"J","ञ":"Y",
+ "ट":"w","ठ":"W","ड":"q","ढ":"Q","ण":"R",
+ "त":"t","थ":"T","द":"d","ध":"D","न":"n",
+ "प":"p","फ":"P","ब":"b","भ":"B","म":"m",
+ "य":"y","र":"r","ल":"l","व":"v",
+ "श":"S","ष":"z","स":"s","ह":"h"
+};
+var DEVA_ANUSVARA = "M";  // ं
+var DEVA_VISARGA = "H";   // ः
+var DEVA_VIRAMA = "्";    // halant: suppresses the inherent 'a'
+var DEVA_AVAGRAHA = "'";  // ऽ
+
+function devanagariToSLP1(text) {
+ var out = "";
+ for (var i = 0; i < text.length; i++) {
+  var c = text[i];
+  var next = text[i + 1];
+  if (DEVA_TO_SLP1_VOWELS[c]) {
+   out += DEVA_TO_SLP1_VOWELS[c];
+  } else if (DEVA_TO_SLP1_CONSONANTS[c]) {
+   out += DEVA_TO_SLP1_CONSONANTS[c];
+   if (next === DEVA_VIRAMA) {
+    i++;  // consonant cluster continues, no inherent 'a'
+   } else if (DEVA_TO_SLP1_MATRAS[next]) {
+    out += DEVA_TO_SLP1_MATRAS[next];
+    i++;
+   } else {
+    out += "a";  // inherent vowel
+   }
+  } else if (c === "ं") {
+   out += DEVA_ANUSVARA;
+  } else if (c === "ः") {
+   out += DEVA_VISARGA;
+  } else if (c === "ऽ") {
+   out += DEVA_AVAGRAHA;
+  } else {
+   out += c;  // spaces, digits, punctuation pass through unchanged
+  }
+ }
+ return out;
+}
+
 function getWord() {
   var word = "";
   if (document.getElementById("key").value) {
@@ -40,10 +96,14 @@ function getWord() {
   var filter = document.getElementById("filter").value;
 //  var filterdir = document.getElementById("filterdir").value;
   var transLit = document.getElementById("transLit").value;
+  if (transLit === "DEVA") {
+   word = devanagariToSLP1(word);
+   transLit = "SLP2SLP";
+  }
   var url = "getWord.php" +
    "?word=" +escape(word) +
    "&transLit=" + escape(transLit) +
-   "&filter=" +escape(filter); 
+   "&filter=" +escape(filter);
 
   request.open("GET", url, true);
   request.onreadystatechange = updatePage;


### PR DESCRIPTION
Adds a client-side Devanagari→SLP1 transliterator so users can type
lookups directly in Devanagari instead of only Harvard-Kyoto/SLP1/ITRANS.

- adds a `Devanagari` choice to the input-scheme `<select>` in `index.php`
- adds `devanagariToSLP1()` to `main.js`, run client-side before the
  `getWord.php` request; the converted word is sent with `transLit=SLP2SLP`
  (the scheme the backend already accepts for SLP1 input) — **no PHP/backend
  changes**
- round-trip verified locally against देव/अग्नि/भू → their known HK spellings
  (deva/agni/BU)

Sibling probe to #17 (mobile CSS, merged) — part of the same Wave U2 usability
pass over `web/`. No dependency between the three; safe to merge independently
or in any order.