### PR TITLE
Add worked examples to help.html

### DIFF
--- a/web/help.html
+++ b/web/help.html
@@ -11,10 +11,36 @@ th {padding-right:5px;}
 The following table shows each abbreviation used in the inflected form
 display, a description of the abbreviation, and a reference to a page
 in Kale's Higher Sanskrit Grammar.<br/>
-Once a word is looked up, one can click on an 
+Once a word is looked up, one can click on an
  <span style="color:blue">abbreviation</span> in the right pane; this
  brings up a display of the page in Kale that discusses this form.
 
+<h3>Worked examples</h3>
+<p>To look up a word: type it into the <b>word</b> box, choose the scheme your
+input is written in from <b>input</b>, choose how you want the output
+displayed from <b>output</b>, then click <b>Go</b> (or press Enter). The
+right-hand pane fills with a table of every inflected form found for that
+word; each row's grammatical tag (e.g. <code>m_a</code>, <code>pre-1a</code>)
+is one of the abbreviations listed below and can be clicked for a Kale
+reference.</p>
+<table border="1">
+<tr><th>word</th><th>input scheme</th><th>what you're looking up</th></tr>
+<tr><td>deva</td><td>Harvard-Kyoto</td>
+ <td>a common <code>m_a</code>-stem noun ("god") &mdash; shows the full
+ nominal declension table (nom./acc./instr./... x sg./du./pl.)</td></tr>
+<tr><td>agni</td><td>Harvard-Kyoto</td>
+ <td>an <code>m_i</code>-stem noun ("fire") &mdash; compare its declension
+ to <code>deva</code> above to see how the <code>i</code>-stem paradigm
+ (Kale 37) differs from the <code>a</code>-stem paradigm (Kale 35)</td></tr>
+<tr><td>BU</td><td>Harvard-Kyoto</td>
+ <td>the verb root "to be/become" &mdash; shows present/imperfect/imperative/
+ optative etc. rows tagged <code>pre-1a</code>, <code>ipf-1a</code>,
+ <code>ipv-1a</code>, <code>opt-1a</code> (class 1, active voice)</td></tr>
+</table>
+<p>Try any of these live:
+<a href="index.php?word=deva&amp;translit=HK">deva</a> &middot;
+<a href="index.php?word=agni&amp;translit=HK">agni</a> &middot;
+<a href="index.php?word=BU&amp;translit=HK">BU</a>.</p>
 
 <table border="1">
 <tr><th>abbr</th><th>description</th><th>reference</th></tr>


### PR DESCRIPTION
Three concrete word lookups (deva, agni, BU) with input scheme and what
the output demonstrates, plus live try-it links, so a first-time user has
a working reference instead of prose-only abbreviation help.

- `deva` — common `m_a`-stem noun, full nominal declension table
- `agni` — `m_i`-stem noun, invites comparison against `deva`'s `a`-stem
  paradigm (Kale 35 vs Kale 37)
- `BU` — verb root "to be/become", present/imperfect/imperative/optative
  rows (`pre-1a`/`ipf-1a`/`ipv-1a`/`opt-1a`)

Each example links straight to `index.php?word=...&translit=HK` so a
reader can try it without retyping. Docs-only change to `web/help.html`,
no code touched.

Sibling probe to #17 (mobile CSS, merged) — part of the same Wave U2
usability pass over `web/`. No dependency on the other two Wave U2 PRs.