### PR TITLE
Polish inflection-table legibility

### DIFF
--- a/web/main.css
+++ b/web/main.css
@@ -42,10 +42,26 @@ p {
  height: 95%;
 /* border: thin; */
 }
-table.decl, table.conj
+table.decl, table.conj, table.tabmain
 {
 border-style: solid;
 border-color: #550555;
+border-collapse: collapse;
+}
+table.decl th, table.conj th
+{
+background-color: #DBE4ED;
+border-style: solid;
+border-color: #550555;
+}
+table.decl td, table.conj td
+{
+border-style: solid;
+border-color: #cccccc;
+}
+table.decl tr:nth-child(even), table.conj tr:nth-child(even)
+{
+background-color: #f4f6f9;
 }
 
 #dispIndex1 {


### PR DESCRIPTION
Pure CSS, scoped to the `table.decl`/`table.conj`/`table.tabmain` classes
`getWord.php` already emits — no markup changes.

- adds cell borders on decl/conj tables (previously only the outer
  `<table>` had a border, not individual header/data cells)
- light header background (`#DBE4ED`) to separate `th` from data rows
- zebra striping (`#f4f6f9` on even rows) for scan-ability on the long
  declension/conjugation tables

Desktop-only change; doesn't touch or conflict with #17's mobile
breakpoint (different selectors: `table.decl`/`.conj`/`.tabmain` here vs
`#leftpane`/`#disp1`/`#disp` there).

Sibling probe to #17 (mobile CSS, merged) — part of the same Wave U2
usability pass over `web/`. No dependency on the other two Wave U2 PRs.